### PR TITLE
Fix extra right white space in mobile devices

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -856,6 +856,16 @@ section .container{
     padding: 0 20px;
 }
 
+section.break-left .container span{
+    right: 0;
+    left: auto;
+}
+
+section.break-right .container span{
+    left: 0;
+    right: auto;
+}
+
 }
 
 /* additional */


### PR DESCRIPTION
This fixes an extra white scroll space on the right side of the screen in mobile devices.